### PR TITLE
docs(repository): Switch to new repository schema

### DIFF
--- a/.repository/index.yaml
+++ b/.repository/index.yaml
@@ -1,0 +1,17 @@
+slug: ci-baseimage
+description: '[DEPRECATED] A super small image to act as a baseimage for continuous integration images.'
+project: cardboardci
+namespace: ci
+status: archived
+icon: icon.svg
+license:
+  type: MIT
+  content: Jonathan Beverly <jrbeverly>
+  year: 2017
+topics: |-
+  [
+    "docker",
+    "docker-ci-images",
+    "alpine",
+    "baseimage"
+  ]


### PR DESCRIPTION
Adopt new repository schema, switching to YAML.

This removes the old JSON + repository schema, switching to using YAML and a project oriented schema. The new project field makes the root of a project clear.

Additionally the language field has been removed as it was a fairly dynamic field.